### PR TITLE
Add threaded ping to check when JL is launched before opening browser

### DIFF
--- a/geoenv/commands/__init__.py
+++ b/geoenv/commands/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F401
 from .bash import bash_parser
 from .jupyter_lab import jl_parser
 from .postgres import postgres_parser

--- a/geoenv/commands/core.py
+++ b/geoenv/commands/core.py
@@ -1,6 +1,12 @@
 import argparse
+import contextlib
+import logging
 import os
 import subprocess
+import threading
+import time
+import urllib.request
+from datetime import datetime
 
 GEOENV_NETWORK = "geoenv-network"
 GEOENV_CONTAINER_NAME = "geoenv-container"
@@ -14,6 +20,14 @@ _exposed_ports = []
 
 main_parser = argparse.ArgumentParser(prog="geoenv")
 sub_parsers = main_parser.add_subparsers(dest="command", required=True)
+
+
+def threaded(fn):
+    def _run(*k, **kw):
+        t = threading.Thread(target=fn, args=k, kwargs=kw)
+        t.start()
+
+    return _run
 
 
 def register_port(port: int):
@@ -59,6 +73,21 @@ def run(func):
         return True
 
     return inner
+
+
+def ping(url: str, timeout: int = 30, timeout_message: str = ""):
+    start_ts = datetime.now().timestamp()
+    while True:
+        with contextlib.suppress(Exception):
+            with urllib.request.urlopen(url) as r:
+                if r.status < 400:
+                    return True
+
+        if start_ts + timeout < datetime.now().timestamp():
+            logging.error(f"{timeout_message}\n")
+            return False
+
+        time.sleep(1)
 
 
 def is_container_running(container_name):

--- a/geoenv/commands/jupyter_lab.py
+++ b/geoenv/commands/jupyter_lab.py
@@ -1,10 +1,19 @@
-import subprocess
 import uuid
 
-from .core import interactive, register_port, sub_parsers
-
+from .core import interactive, ping, register_port, run, sub_parsers, threaded
 
 register_port(8001)
+
+
+@threaded
+@run
+def open_in_browser(url: str):
+    if ping(
+        url,
+        timeout_message=f"Not able to automatically open url in browser [{url}]"
+    ):
+        return f"python -m webbrowser {url}"
+    return None
 
 
 def handler(parser_args, *args, **kwargs):
@@ -12,10 +21,8 @@ def handler(parser_args, *args, **kwargs):
     if parser_args.no_browser is False:
         key = uuid.uuid4()
         jl_key = f"--NotebookApp.token='{key}'"
-        subprocess.Popen(
-            [f"sleep 3;python -m webbrowser http://localhost:8001/lab?token={key}"],
-            shell=True,
-        )
+        url = f"http://localhost:8001/lab?token={key}"
+        open_in_browser(url)
 
     interactive(
         lambda: f"jupyter lab {jl_key} --app_dir=/app/ --port=8001 --ip=0.0.0.0 --allow-root"


### PR DESCRIPTION
Browser opens Jupyter Notebook before the server is running and you get a browser error.

## Changes

Add a ping function to can check when url is returning successful response before launching Jupyter in the browser

fixes: https://github.com/gridcell/geoenv-cli/issues/1